### PR TITLE
fix: 修复remax/alipay 改名为remax/ali 的问题

### DIFF
--- a/src/pages/index/index.tsx
+++ b/src/pages/index/index.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { View, Text, Image } from 'remax/alipay';
+import { View, Text, Image } from 'remax/ali';
 import styles from './index.css';
 
 export default () => {


### PR DESCRIPTION
remax/alipay 在2.x中初始化的项目是有问题的